### PR TITLE
Removed dependency on money-ri-platform in money-impl/pom.xml

### DIFF
--- a/money-impl/pom.xml
+++ b/money-impl/pom.xml
@@ -57,11 +57,6 @@
 				<version>${javamoney.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>javax.money</groupId>
-				<artifactId>money-platform-ri</artifactId>
-				<version>${javamoney.version}</version>
-			</dependency>
-			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>${junit.version}</version>
@@ -97,10 +92,6 @@
 		<dependency>
 			<groupId>javax.money</groupId>
 			<artifactId>money-api-format</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax.money</groupId>
-			<artifactId>money-platform-ri</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.inject</groupId>


### PR DESCRIPTION
Removing the (unnecessary?) dependency on money-ri-platform in money-impl/pom.xml fixed the build issue.

There remain some references to money-platform-ri, as follows:

$ grep -ri "money-platform-ri" *
money-api/convert/pom.xml:          <artifactId>money-platform-ri</artifactId>
money-api/ext/pom.xml:          <artifactId>money-platform-ri</artifactId>
money-api/format/pom.xml:           <artifactId>money-platform-ri</artifactId>

and many of these use the javax.money group instead of net.java.javamoney, so it may be a wider review is required.
