### PR TITLE
Update non null check in ExchangeRate.java

### DIFF
--- a/src/main/java/javax/money/convert/ExchangeRate.java
+++ b/src/main/java/javax/money/convert/ExchangeRate.java
@@ -141,7 +141,7 @@ public final class ExchangeRate implements Serializable, Comparable<ExchangeRate
         Objects.requireNonNull(builder.base, "base may not be null.");
         Objects.requireNonNull(builder.term, "term may not be null.");
         Objects.requireNonNull(builder.factor, "factor may not be null.");
-        Objects.requireNonNull(builder.base, "exchangeRateType may not be null.");
+        Objects.requireNonNull(builder.conversionContext, "exchangeRateType may not be null.");
         this.base = builder.base;
         this.term = builder.term;
         this.factor = builder.factor;


### PR DESCRIPTION
non null check for builder.base was performed twice. Tried to make the change for "exchangeRateType may not be null" exception message. Please review.
