### PR TITLE
removing  boxing and unboxing unnecessary

### DIFF
--- a/src/test/java/javax/money/AbstractContextTest.java
+++ b/src/test/java/javax/money/AbstractContextTest.java
@@ -50,10 +50,10 @@ public class AbstractContextTest{
 
     @Test
     public void testSetWithKeyAndType() {
-        TestContext ctx = new TestContext.Builder().setAttribute("MyNum", Integer.valueOf(2), Number.class).build();
+        TestContext ctx = new TestContext.Builder().setAttribute("MyNum", 2, Number.class).build();
         assertNull(ctx.getAttribute(String.class));
         assertEquals("myKey", ctx.getAttribute(String.class, "myKey"));
-        assertEquals(ctx.getNamedAttribute("MyNum", Number.class), Integer.valueOf(2));
+        assertEquals(ctx.getNamedAttribute("MyNum", Number.class), 2);
         assertEquals(ctx.getNamedAttribute("MyNum", Integer.class), null);
     }
 
@@ -67,7 +67,7 @@ public class AbstractContextTest{
 
     @Test
     public void testGetAttributeTypes(){
-        TestContext ctx = new TestContext.Builder().setObject("Test").setObject(Integer.valueOf(2)).setObject(Long.valueOf(2)).build();
+        TestContext ctx = new TestContext.Builder().setObject("Test").setObject(2).setObject((long) 2).build();
         Set<Class<?>> types = ctx.getAttributeTypes();
         assertNotNull(types);
         assertTrue(types.size()==3);
@@ -79,10 +79,10 @@ public class AbstractContextTest{
     @Test
     public void testHashCode() {
         List<TestContext> contexts = new ArrayList<>();
-        contexts.add(new TestContext.Builder().setObject("Test").setObject(Integer.valueOf(1)).setObject(Long.valueOf(2)).build());
-        contexts.add(new TestContext.Builder().setObject("Test").setObject(Integer.valueOf(2)).setObject(Long.valueOf(1)).build());
-        contexts.add(new TestContext.Builder().setObject("Test").setObject(Integer.valueOf(2)).build());
-        contexts.add(new TestContext.Builder().setObject("Test").setObject(Long.valueOf(2)).build());
+        contexts.add(new TestContext.Builder().setObject("Test").setObject(1).setObject((long) 2).build());
+        contexts.add(new TestContext.Builder().setObject("Test").setObject(2).setObject((long) 1).build());
+        contexts.add(new TestContext.Builder().setObject("Test").setObject(2).build());
+        contexts.add(new TestContext.Builder().setObject("Test").setObject((long) 2).build());
         contexts.add(new TestContext.Builder().setObject("Test").setObject(Boolean.TRUE).setObject("Test").build());
         Set<Integer> hashCodes = new HashSet<>();
         for(TestContext ctx : contexts){
@@ -95,10 +95,10 @@ public class AbstractContextTest{
     @Test
     public void testEquals() {
         List<TestContext> contexts = new ArrayList<>();
-        contexts.add(new TestContext.Builder().setObject("Test").setObject(Integer.valueOf(11)).setObject(Long.valueOf(2)).build());
-        contexts.add(new TestContext.Builder().setObject("Test").setObject(Integer.valueOf(2)).setObject(Long.valueOf(11)).build());
-        contexts.add(new TestContext.Builder().setObject("Test").setObject(Integer.valueOf(2)).build());
-        contexts.add(new TestContext.Builder().setObject("Test").setObject(Long.valueOf(2)).build());
+        contexts.add(new TestContext.Builder().setObject("Test").setObject(11).setObject((long) 2).build());
+        contexts.add(new TestContext.Builder().setObject("Test").setObject(2).setObject((long) 11).build());
+        contexts.add(new TestContext.Builder().setObject("Test").setObject(2).build());
+        contexts.add(new TestContext.Builder().setObject("Test").setObject((long) 2).build());
         contexts.add(new TestContext.Builder().setObject("Test").setObject(Boolean.TRUE).setObject("Test").build());
         Set<TestContext> checkContexts = new HashSet<>();
         for(TestContext ctx : contexts){
@@ -111,7 +111,7 @@ public class AbstractContextTest{
 
     @Test
     public void testToString() {
-        TestContext ctx = new TestContext.Builder().setObject("Test").setObject(Integer.valueOf(1)).setObject(Long.valueOf(2)).build();
+        TestContext ctx = new TestContext.Builder().setObject("Test").setObject(1).setObject((long) 2).build();
         assertNotNull(ctx.toString());
         System.out.println(ctx.toString());
         assertTrue(ctx.toString().contains("1"));

--- a/src/test/java/javax/money/spi/BootstrapTest.java
+++ b/src/test/java/javax/money/spi/BootstrapTest.java
@@ -108,7 +108,7 @@ public class BootstrapTest{
     @Test
     public void testGetService1() throws Exception{
         Bootstrap.init(new TestServiceProvider());
-        Long num = Bootstrap.getService(Long.class, Long.valueOf(111L));
+        Long num = Bootstrap.getService(Long.class, 111L);
         assertNotNull(num);
         assertTrue(num.equals(111L));
     }
@@ -121,10 +121,10 @@ public class BootstrapTest{
                 return List.class.cast(Arrays.asList(new String[]{"service1", "service2"}));
             }
             else if(Integer.class.equals(serviceType)){
-                return List.class.cast(Arrays.asList(new Integer[]{Integer.valueOf(5)}));
+                return List.class.cast(Arrays.asList(new Integer[]{5}));
             }
             else if(Long.class.equals(serviceType)){
-                return List.class.cast(Arrays.asList(new Long[]{Long.valueOf(111)}));
+                return List.class.cast(Arrays.asList(new Long[]{(long) 111}));
             }
             return Collections.emptyList();
         }
@@ -135,10 +135,10 @@ public class BootstrapTest{
                 return List.class.cast(Arrays.asList(new String[]{"service1", "service2"}));
             }
             else if(Integer.class.equals(serviceType)){
-                return List.class.cast(Arrays.asList(new Integer[]{Integer.valueOf(5)}));
+                return List.class.cast(Arrays.asList(new Integer[]{5}));
             }
             else if(Long.class.equals(serviceType)){
-                return List.class.cast(Arrays.asList(new Long[]{Long.valueOf(111)}));
+                return List.class.cast(Arrays.asList(new Long[]{(long) 111}));
             }
             return defaultList;
         }


### PR DESCRIPTION
With Java 5 use boxing and unboxing are unnecessary because it is made automatically by JVM, it doesn't impact on performance, but get the code more clean.
