### PR TITLE
fix compare to

### DIFF
--- a/src/test/java/javax/money/DummyAmount.java
+++ b/src/test/java/javax/money/DummyAmount.java
@@ -8,6 +8,8 @@
  */
 package javax.money;
 
+import java.util.Objects;
+
 /**
  * Amount pseudo (non functional) implementation, for testing only.
  * 
@@ -322,6 +324,7 @@ public final class DummyAmount implements
 
     @Override
     public int compareTo(MonetaryAmount o){
+    	Objects.requireNonNull(o);
         return 0;
     }
 }

--- a/src/test/java/javax/money/TestCurrency.java
+++ b/src/test/java/javax/money/TestCurrency.java
@@ -131,6 +131,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable,
 	}
 
 	public int compareTo(CurrencyUnit currency) {
+		Objects.requireNonNull(currency);
 		return getCurrencyCode().compareTo(currency.getCurrencyCode());
 	}
 
@@ -261,6 +262,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable,
 		// }
 
 		public int compareTo(CurrencyUnit currency) {
+			Objects.requireNonNull(currency);
 			int compare = getCurrencyCode().compareTo(
 					currency.getCurrencyCode());
 			if (compare == 0) {

--- a/src/test/java/javax/money/TestCurrencyProvider.java
+++ b/src/test/java/javax/money/TestCurrencyProvider.java
@@ -115,6 +115,7 @@ public final class TestCurrencyProvider implements CurrencyProviderSpi{
 		}
         @Override
         public int compareTo(CurrencyUnit o){
+        	Objects.requireNonNull(o);
             return getCurrencyCode().compareTo(o.getCurrencyCode());
         }
     }

--- a/src/test/java/javax/money/convert/DefaultExchangeRate.java
+++ b/src/test/java/javax/money/convert/DefaultExchangeRate.java
@@ -216,9 +216,7 @@ public class DefaultExchangeRate implements ExchangeRate, Serializable, Comparab
      */
     @Override
     public int compareTo(ExchangeRate o){
-        if(Objects.isNull(o)){
-            return -1;
-        }
+        Objects.requireNonNull(o);
         int compare = this.getBase().getCurrencyCode().compareTo(o.getBase().getCurrencyCode());
         if(compare == 0){
             compare = this.getTerm().getCurrencyCode().compareTo(o.getTerm().getCurrencyCode());


### PR DESCRIPTION
By documentations compareTo should returns NPE when the object is null.
Using Objects.requireNonNull it avoid the JIT blind the class and then make it slower.
https://bugs.openjdk.java.net/browse/JDK-8042127
