### PR TITLE
getNumberType() return Class<? extends Number>

### DIFF
--- a/src/main/java/javax/money/NumberValue.java
+++ b/src/main/java/javax/money/NumberValue.java
@@ -39,7 +39,7 @@ public abstract class NumberValue extends Number implements Comparable<NumberVal
      *
      * @return the numeric implementation type, not {@code null}.
      */
-    public abstract Class<?> getNumberType();
+    public abstract Class<? extends Number> getNumberType();
 
     /**
      * Returns the <i>precision</i> of this {@code MonetaryAmount}. (The precision is the number of

--- a/src/test/java/javax/money/DummyAmount.java
+++ b/src/test/java/javax/money/DummyAmount.java
@@ -144,8 +144,8 @@ public final class DummyAmount implements MonetaryAmount {
             }
 
             @Override
-            public Class<?> getNumberType() {
-                return Void.class;
+            public Class<? extends Number> getNumberType() {
+                return Number.class;
             }
         };
     }

--- a/src/test/java/javax/money/convert/TestNumberValue.java
+++ b/src/test/java/javax/money/convert/TestNumberValue.java
@@ -62,7 +62,7 @@ public class TestNumberValue extends NumberValue {
 	 * @see javax.money.NumberValue#getNumberType()
 	 */
 	@Override
-	public Class<?> getNumberType() {
+	public Class<? extends Number> getNumberType() {
 		return this.number.getClass();
 	}
 


### PR DESCRIPTION
getNumberType() should provide an explicit guarantee that
the type returned extends Number. So it should return:

Class<? extends Number>

instead of

Class<?>
