### PR TITLE
Make CurrencyUnit extend java.io.Serializable

### DIFF
--- a/src/main/java/javax/money/CurrencyUnit.java
+++ b/src/main/java/javax/money/CurrencyUnit.java
@@ -10,6 +10,8 @@
  */
 package javax.money;
 
+import java.io.Serializable;
+
 /**
  * A unit of currency.
  * <p>
@@ -38,7 +40,7 @@ package javax.money;
  * 
  * @see <a href="https://en.wikipedia.org/wiki/Currency">Wikipedia: Currency</a>
  */
-public interface CurrencyUnit extends Comparable<CurrencyUnit>{
+public interface CurrencyUnit extends Comparable<CurrencyUnit>, Serializable {
 
    /**
     * Gets the unique currency code, the effective code depends on the

--- a/src/test/java/javax/money/TestCurrency.java
+++ b/src/test/java/javax/money/TestCurrency.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Werner Keil
  * @version 0.5
  */
-public final class TestCurrency implements CurrencyUnit, Serializable, Comparable<CurrencyUnit> {
+public final class TestCurrency implements CurrencyUnit, Comparable<CurrencyUnit> {
 
     private static final CurrencyContext CONTEXT = CurrencyContextBuilder.of("test-only").build();
 
@@ -209,7 +209,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable, Comparabl
      * @author Anatole Tresch
      * @author Werner Keil
      */
-    private final static class JDKCurrencyAdapter implements CurrencyUnit, Serializable, Comparable<CurrencyUnit> {
+    private final static class JDKCurrencyAdapter implements CurrencyUnit, Comparable<CurrencyUnit> {
 
         private static final CurrencyContext JDK_CONTEXT = CurrencyContextBuilder.of(Currency.class.getName()).build();
 


### PR DESCRIPTION
As per this question:

http://stackoverflow.com/questions/37866041/why-is-javax-money-currencyunit-not-serializable

I would like to suggest to make the javax.money.CurrencyUnit interface extend java.io.Serializable.