### PR TITLE
Make MonetaryAmount Serializable

### DIFF
--- a/src/main/java/javax/money/MonetaryAmount.java
+++ b/src/main/java/javax/money/MonetaryAmount.java
@@ -8,6 +8,8 @@
  */
 package javax.money;
 
+import java.io.Serializable;
+
 /**
  * Interface defining a monetary amount. The effective format representation of an amount may vary
  * depending on the implementation used. JSR 354 explicitly supports different types of monetary
@@ -93,7 +95,7 @@ package javax.money;
  * @version 0.8.2
  * @see #with(MonetaryOperator)
  */
-public interface MonetaryAmount extends CurrencySupplier, NumberSupplier, Comparable<MonetaryAmount>{
+public interface MonetaryAmount extends CurrencySupplier, NumberSupplier, Comparable<MonetaryAmount>, Serializable{
 
     /**
      * Returns the {@link MonetaryContext} of this {@code MonetaryAmount}. The


### PR DESCRIPTION
I'm submitting this pull request to make the MonetaryAmount interface Serializable.

I realize the authors of the specification may have already discussed this and decided purposefully to not make the MonetaryAmount interface Serializable, but I have not been able to find any discussion about this.  If so, then I would like to start a discussion, even if only for my own understanding, as to why it was decided that MonetaryAmount itself would not be Serializable. 



