### PR TITLE
Removed static references to SPI instances.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<artifactId>money-api</artifactId>
 	<packaging>bundle</packaging>
 
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<name>JSR 354 (Money and Currency API)</name>
 	<url>http://java.net/projects/javamoney</url>
 	<inceptionYear>2012</inceptionYear>
@@ -34,6 +34,7 @@
 		<basedir>.</basedir>
 		<!-- Dependency versions -->
 		<testng.version>6.8.5</testng.version>
+        <mockito.version>1.10.19</mockito.version>
 	</properties>
 
 	<organization>
@@ -399,6 +400,12 @@
 				<version>${testng.version}</version>
 				<scope>test</scope>
 			</dependency>
+            <dependency>
+              <groupId>org.mockito</groupId>
+              <artifactId>mockito-all</artifactId>
+              <version>${mockito.version}</version>
+              <scope>test</scope>
+            </dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -408,6 +415,11 @@
 			<artifactId>testng</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/javax/money/Monetary.java
+++ b/src/main/java/javax/money/Monetary.java
@@ -41,23 +41,60 @@ public final class Monetary {
     /**
      * The used {@link javax.money.spi.MonetaryCurrenciesSingletonSpi} instance.
      */
-    private static final MonetaryCurrenciesSingletonSpi MONETARY_CURRENCIES_SINGLETON_SPI = loadMonetaryCurrenciesSingletonSpi();
+    private static final MonetaryCurrenciesSingletonSpi MONETARY_CURRENCIES_SINGLETON_SPI() {
+        try {
+            return Optional.ofNullable(Bootstrap
+                    .getService(MonetaryCurrenciesSingletonSpi.class)).orElseGet(
+                    DefaultMonetaryCurrenciesSingletonSpi::new);
+        } catch (Exception e) {
+            Logger.getLogger(Monetary.class.getName())
+                    .log(Level.INFO, "Failed to load MonetaryCurrenciesSingletonSpi, using default.", e);
+            return new DefaultMonetaryCurrenciesSingletonSpi();
+        }
+    }
 
     /**
      * The used {@link javax.money.spi.MonetaryAmountsSingletonSpi} instance.
      */
-    private static final MonetaryAmountsSingletonSpi MONETARY_AMOUNTS_SINGLETON_SPI = loadMonetaryAmountsSingletonSpi();
+    private static final MonetaryAmountsSingletonSpi MONETARY_AMOUNTS_SINGLETON_SPI() {
+        try {
+            return Bootstrap.getService(MonetaryAmountsSingletonSpi.class);
+        } catch (Exception e) {
+            Logger.getLogger(Monetary.class.getName())
+                    .log(Level.SEVERE, "Failed to load MonetaryAmountsSingletonSpi.", e);
+            return null;
+        }
+    }
 
     /**
      * The used {@link javax.money.spi.MonetaryAmountsSingletonSpi} instance.
      */
-    private static final MonetaryAmountsSingletonQuerySpi MONETARY_AMOUNTS_SINGLETON_QUERY_SPI =
-            loadMonetaryAmountsSingletonQuerySpi();
+    private static final MonetaryAmountsSingletonQuerySpi MONETARY_AMOUNTS_SINGLETON_QUERY_SPI() {
+        try {
+            return Bootstrap.getService(MonetaryAmountsSingletonQuerySpi.class);
+        } catch (Exception e) {
+            Logger.getLogger(Monetary.class.getName()).log(Level.SEVERE, "Failed to load " +
+                    "MonetaryAmountsSingletonQuerySpi, " +
+                    "query functionality will not be " +
+                    "available.", e);
+            return null;
+        }
+    }
 
     /**
      * The used {@link javax.money.spi.MonetaryCurrenciesSingletonSpi} instance.
      */
-    private static final MonetaryRoundingsSingletonSpi MONETARY_ROUNDINGS_SINGLETON_SPI = loadMonetaryRoundingsSingletonSpi();
+    private static final MonetaryRoundingsSingletonSpi MONETARY_ROUNDINGS_SINGLETON_SPI() {
+        try {
+            return Optional.ofNullable(Bootstrap
+                    .getService(MonetaryRoundingsSingletonSpi.class))
+                    .orElseGet(DefaultMonetaryRoundingsSingletonSpi::new);
+        } catch (Exception e) {
+            Logger.getLogger(Monetary.class.getName())
+                    .log(Level.SEVERE, "Failed to load MonetaryCurrenciesSingletonSpi, using default.", e);
+            return new DefaultMonetaryRoundingsSingletonSpi();
+        }
+    }
 
     /**
      * Required for deserialization only.
@@ -71,11 +108,10 @@ public final class Monetary {
      * @return the set of provider names, never {@code null}.
      */
     public static Set<String> getRoundingProviderNames() {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .getProviderNames();
     }
-
 
     /**
      * Allows to access the default providers chain used if no provider chain was passed explicitly..
@@ -83,76 +119,9 @@ public final class Monetary {
      * @return the chained list of provider names, never {@code null}.
      */
     public static List<String> getDefaultRoundingProviderChain() {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .getDefaultProviderChain();
-    }
-
-
-    /**
-     * Loads the SPI backing bean.
-     *
-     * @return the {@link MonetaryCurrenciesSingletonSpi} backing bean to be used.
-     */
-    private static MonetaryCurrenciesSingletonSpi loadMonetaryCurrenciesSingletonSpi() {
-        try {
-            return Optional.ofNullable(Bootstrap
-                    .getService(MonetaryCurrenciesSingletonSpi.class)).orElseGet(
-                    DefaultMonetaryCurrenciesSingletonSpi::new);
-        } catch (Exception e) {
-            Logger.getLogger(Monetary.class.getName())
-                    .log(Level.INFO, "Failed to load MonetaryCurrenciesSingletonSpi, using default.", e);
-            return new DefaultMonetaryCurrenciesSingletonSpi();
-        }
-    }
-
-    /**
-     * Loads the SPI backing bean.
-     *
-     * @return the MonetaryAmountsSingletonSpi bean from the bootstrapping logic.
-     */
-    private static MonetaryAmountsSingletonSpi loadMonetaryAmountsSingletonSpi() {
-        try {
-            return Bootstrap.getService(MonetaryAmountsSingletonSpi.class);
-        } catch (Exception e) {
-            Logger.getLogger(Monetary.class.getName())
-                    .log(Level.SEVERE, "Failed to load MonetaryAmountsSingletonSpi.", e);
-            return null;
-        }
-    }
-
-    /**
-     * Loads the SPI backing bean.
-     *
-     * @return the MonetaryAmountsSingletonQuerySpi bean from the bootstrapping logic.
-     */
-    private static MonetaryAmountsSingletonQuerySpi loadMonetaryAmountsSingletonQuerySpi() {
-        try {
-            return Bootstrap.getService(MonetaryAmountsSingletonQuerySpi.class);
-        } catch (Exception e) {
-            Logger.getLogger(Monetary.class.getName()).log(Level.SEVERE, "Failed to load " +
-                    "MonetaryAmountsSingletonQuerySpi, " +
-                    "query functionality will not be " +
-                    "available.", e);
-            return null;
-        }
-    }
-
-    /**
-     * Loads the SPI backing bean.
-     *
-     * @return an instance of MonetaryRoundingsSingletonSpi.
-     */
-    private static MonetaryRoundingsSingletonSpi loadMonetaryRoundingsSingletonSpi() {
-        try {
-            return Optional.ofNullable(Bootstrap
-                    .getService(MonetaryRoundingsSingletonSpi.class))
-                    .orElseGet(DefaultMonetaryRoundingsSingletonSpi::new);
-        } catch (Exception e) {
-            Logger.getLogger(Monetary.class.getName())
-                    .log(Level.SEVERE, "Failed to load MonetaryCurrenciesSingletonSpi, using default.", e);
-            return new DefaultMonetaryRoundingsSingletonSpi();
-        }
     }
 
     /**
@@ -164,11 +133,10 @@ public final class Monetary {
      * @return the (shared) default rounding instance.
      */
     public static MonetaryRounding getDefaultRounding() {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .getDefaultRounding();
     }
-
 
     /**
      * Creates an {@link MonetaryOperator} for rounding {@link MonetaryAmount}
@@ -183,7 +151,7 @@ public final class Monetary {
      * rounding, never {@code null}.
      */
     public static MonetaryRounding getRounding(CurrencyUnit currencyUnit, String... providers) {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .getRounding(currencyUnit, providers);
     }
@@ -201,7 +169,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static MonetaryRounding getRounding(String roundingName, String... providers) {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .getRounding(roundingName, providers);
     }
@@ -216,7 +184,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static MonetaryRounding getRounding(RoundingQuery roundingQuery) {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .getRounding(roundingQuery);
     }
@@ -232,7 +200,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static boolean isRoundingAvailable(String roundingName, String... providers) {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .isRoundingAvailable(roundingName, providers);
     }
@@ -249,7 +217,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static boolean isRoundingAvailable(CurrencyUnit currencyUnit, String... providers) {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .isRoundingAvailable(currencyUnit, providers);
     }
@@ -264,7 +232,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static boolean isRoundingAvailable(RoundingQuery roundingQuery) {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .isRoundingAvailable(roundingQuery);
     }
@@ -278,7 +246,7 @@ public final class Monetary {
      * @return all {@link javax.money.MonetaryRounding} instances matching the query, never {@code null}.
      */
     public static Collection<MonetaryRounding> getRoundings(RoundingQuery roundingQuery) {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .getRoundings(roundingQuery);
     }
@@ -292,7 +260,7 @@ public final class Monetary {
      * @return the set of custom rounding ids, never {@code null}.
      */
     public static Set<String> getRoundingNames(String... providers) {
-        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_ROUNDINGS_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
                 .getRoundingNames(providers);
     }
@@ -307,10 +275,10 @@ public final class Monetary {
      *                           implementation class is registered.
      */
     public static <T extends MonetaryAmount> MonetaryAmountFactory<T> getAmountFactory(Class<T> amountType) {
-        Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI)
+        Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI())
                 .orElseThrow(() -> new MonetaryException("No MonetaryAmountsSingletonSpi loaded."));
 
-        MonetaryAmountFactory<T> factory = MONETARY_AMOUNTS_SINGLETON_SPI.getAmountFactory(amountType);
+        MonetaryAmountFactory<T> factory = MONETARY_AMOUNTS_SINGLETON_SPI().getAmountFactory(amountType);
         return Optional.ofNullable(factory).orElseThrow(
                 () -> new MonetaryException("No AmountFactory available for type: " + amountType.getName()));
     }
@@ -325,7 +293,7 @@ public final class Monetary {
      *                           implementation class is registered.
      */
     public static MonetaryAmountFactory<?> getDefaultAmountFactory() {
-        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI)
+        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI())
                 .orElseThrow(() -> new MonetaryException("No MonetaryAmountsSingletonSpi loaded."))
                 .getDefaultAmountFactory();
     }
@@ -338,7 +306,7 @@ public final class Monetary {
      * corresponding {@link MonetaryAmountFactory} instances provided, never {@code null}
      */
     public static Collection<MonetaryAmountFactory<?>> getAmountFactories() {
-        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI)
+        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI())
                 .orElseThrow(() -> new MonetaryException("No MonetaryAmountsSingletonSpi loaded."))
                 .getAmountFactories();
     }
@@ -351,7 +319,7 @@ public final class Monetary {
      * corresponding {@link MonetaryAmountFactory} instances provided, never {@code null}
      */
     public static Collection<Class<? extends MonetaryAmount>> getAmountTypes() {
-        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI)
+        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI())
                 .orElseThrow(() -> new MonetaryException("No MonetaryAmountsSingletonSpi loaded.")).getAmountTypes();
     }
 
@@ -362,7 +330,7 @@ public final class Monetary {
      * @return all current default {@link MonetaryAmount} implementation class, never {@code null}
      */
     public static Class<? extends MonetaryAmount> getDefaultAmountType() {
-        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI)
+        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_SPI())
                 .orElseThrow(() -> new MonetaryException("No MonetaryAmountsSingletonSpi loaded."))
                 .getDefaultAmountType();
     }
@@ -376,7 +344,7 @@ public final class Monetary {
      */
     @SuppressWarnings("rawtypes")
 	public static MonetaryAmountFactory getAmountFactory(MonetaryAmountFactoryQuery query) {
-        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_QUERY_SPI).orElseThrow(() -> new MonetaryException(
+        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_QUERY_SPI()).orElseThrow(() -> new MonetaryException(
                 "No MonetaryAmountsSingletonQuerySpi loaded, query functionality is not available."))
                 .getAmountFactory(query);
     }
@@ -388,7 +356,7 @@ public final class Monetary {
      * @return the instances found, never null.
      */
     public static Collection<MonetaryAmountFactory<?>> getAmountFactories(MonetaryAmountFactoryQuery query) {
-        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_QUERY_SPI).orElseThrow(() -> new MonetaryException(
+        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_QUERY_SPI()).orElseThrow(() -> new MonetaryException(
                 "No MonetaryAmountsSingletonQuerySpi loaded, query functionality is not available."))
                 .getAmountFactories(query);
     }
@@ -401,7 +369,7 @@ public final class Monetary {
      * @return true, if at least one {@link MonetaryAmountFactory} matches the query.
      */
     public static boolean isAvailable(MonetaryAmountFactoryQuery query) {
-        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_QUERY_SPI).orElseThrow(() -> new MonetaryException(
+        return Optional.ofNullable(MONETARY_AMOUNTS_SINGLETON_QUERY_SPI()).orElseThrow(() -> new MonetaryException(
                 "No MonetaryAmountsSingletonQuerySpi loaded, query functionality is not available."))
                 .isAvailable(query);
     }
@@ -417,7 +385,7 @@ public final class Monetary {
      * @throws UnknownCurrencyException if no such currency exists.
      */
     public static CurrencyUnit getCurrency(String currencyCode, String... providers) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getCurrency(currencyCode, providers);
     }
@@ -434,7 +402,7 @@ public final class Monetary {
      * @throws UnknownCurrencyException if no such currency exists.
      */
     public static CurrencyUnit getCurrency(Locale locale, String... providers) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getCurrency(locale, providers);
     }
@@ -451,7 +419,7 @@ public final class Monetary {
      * @throws UnknownCurrencyException if no such currency exists.
      */
     public static Set<CurrencyUnit> getCurrencies(Locale locale, String... providers) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getCurrencies(locale, providers);
     }
@@ -466,7 +434,7 @@ public final class Monetary {
      * would return a result for the given code.
      */
     public static boolean isCurrencyAvailable(String code, String... providers) {
-        return Objects.nonNull(MONETARY_CURRENCIES_SINGLETON_SPI) && MONETARY_CURRENCIES_SINGLETON_SPI.isCurrencyAvailable(code, providers);
+        return Objects.nonNull(MONETARY_CURRENCIES_SINGLETON_SPI()) && MONETARY_CURRENCIES_SINGLETON_SPI().isCurrencyAvailable(code, providers);
     }
 
     /**
@@ -479,7 +447,7 @@ public final class Monetary {
      * result containing a currency with the given code.
      */
     public static boolean isCurrencyAvailable(Locale locale, String... providers) {
-        return Objects.nonNull(MONETARY_CURRENCIES_SINGLETON_SPI) && MONETARY_CURRENCIES_SINGLETON_SPI.isCurrencyAvailable(locale, providers);
+        return Objects.nonNull(MONETARY_CURRENCIES_SINGLETON_SPI()) && MONETARY_CURRENCIES_SINGLETON_SPI().isCurrencyAvailable(locale, providers);
     }
 
     /**
@@ -489,7 +457,7 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static Collection<CurrencyUnit> getCurrencies(String... providers) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getCurrencies(providers);
     }
@@ -501,7 +469,7 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static CurrencyUnit getCurrency(CurrencyQuery query) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getCurrency(query);
     }
@@ -514,7 +482,7 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static Collection<CurrencyUnit> getCurrencies(CurrencyQuery query) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getCurrencies(query);
     }
@@ -525,7 +493,7 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static Set<String> getCurrencyProviderNames() {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getProviderNames();
     }
@@ -537,7 +505,7 @@ public final class Monetary {
      * @return the ordered list provider names, modelling the default provider chain used, never null.
      */
     public static List<String> getDefaultCurrencyProviderChain() {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI).orElseThrow(
+        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getDefaultProviderChain();
     }

--- a/src/main/java/javax/money/convert/MonetaryConversions.java
+++ b/src/main/java/javax/money/convert/MonetaryConversions.java
@@ -56,8 +56,9 @@ public final class MonetaryConversions{
      * The SPI currently active, use {@link ServiceLoader} to register an
      * alternate implementation.
      */
-    private static final MonetaryConversionsSingletonSpi MONETARY_CONVERSION_SPI = Optional.of(
-            Bootstrap.getService(MonetaryConversionsSingletonSpi.class)).get();
+    private static final MonetaryConversionsSingletonSpi getMonetaryConversionsSpi() {
+        return Optional.of(Bootstrap.getService(MonetaryConversionsSingletonSpi.class)).get();
+    }
 
     /**
      * Private singleton constructor.
@@ -78,11 +79,11 @@ public final class MonetaryConversions{
         Objects.requireNonNull(providers);
         Objects.requireNonNull(termCurrency);
         if(providers.length == 0){
-            return MONETARY_CONVERSION_SPI.getConversion(
+            return getMonetaryConversionsSpi().getConversion(
                     ConversionQueryBuilder.of().setTermCurrency(termCurrency).setProviderNames(getDefaultConversionProviderChain())
                             .build());
         }
-        return MONETARY_CONVERSION_SPI.getConversion(
+        return getMonetaryConversionsSpi().getConversion(
                 ConversionQueryBuilder.of().setTermCurrency(termCurrency).setProviderNames(providers).build());
     }
 
@@ -110,7 +111,7 @@ public final class MonetaryConversions{
      * @throws IllegalArgumentException if the query defines {@link ExchangeRateProvider}s that are not available.
      */
     public static CurrencyConversion getConversion(ConversionQuery conversionQuery){
-        return Optional.ofNullable(MONETARY_CONVERSION_SPI)
+        return Optional.ofNullable(getMonetaryConversionsSpi())
                 .orElseThrow(() -> new MonetaryException("No MonetaryConversionsSingletonSpi " +
                                                                  "loaded, " +
                                                                  "query functionality is not " +
@@ -124,7 +125,7 @@ public final class MonetaryConversions{
      * @return true, if a conversion is accessible from {@link #getConversion(ConversionQuery)}.
      */
     public static boolean isConversionAvailable(ConversionQuery conversionQuery){
-        return Optional.ofNullable(MONETARY_CONVERSION_SPI)
+        return Optional.ofNullable(getMonetaryConversionsSpi())
                 .orElseThrow(() -> new MonetaryException("No MonetaryConversionsSingletonSpi " +
                                                                  "loaded, " +
                                                                  "query functionality is not " +
@@ -140,7 +141,7 @@ public final class MonetaryConversions{
      * @return true, if a conversion is accessible from {@link #getConversion(String, String...)}.
      */
     public static boolean isConversionAvailable(String currencyCode, String... providers){
-        return Optional.ofNullable(MONETARY_CONVERSION_SPI)
+        return Optional.ofNullable(getMonetaryConversionsSpi())
                 .orElseThrow(() -> new MonetaryException("No MonetaryConversionsSingletonSpi " +
                                                                  "loaded, " +
                                                                  "query functionality is not " +
@@ -156,7 +157,7 @@ public final class MonetaryConversions{
      * @return true, if a conversion is accessible from {@link #getConversion(String, String...)}.
      */
     public static boolean isConversionAvailable(CurrencyUnit termCurrency, String... providers){
-        return Optional.ofNullable(MONETARY_CONVERSION_SPI)
+        return Optional.ofNullable(getMonetaryConversionsSpi())
                 .orElseThrow(() -> new MonetaryException("No MonetaryConversionsSingletonSpi " +
                                                                  "loaded, " +
                                                                  "query functionality is not " +
@@ -175,10 +176,10 @@ public final class MonetaryConversions{
     public static ExchangeRateProvider getExchangeRateProvider(String... providers){
         if(providers.length == 0){
             List<String> defaultProviderChain = getDefaultConversionProviderChain();
-            return MONETARY_CONVERSION_SPI.getExchangeRateProvider(ConversionQueryBuilder.of().setProviderNames(
+            return getMonetaryConversionsSpi().getExchangeRateProvider(ConversionQueryBuilder.of().setProviderNames(
                     defaultProviderChain.toArray(new String[defaultProviderChain.size()])).build());
         }
-        ExchangeRateProvider provider = MONETARY_CONVERSION_SPI
+        ExchangeRateProvider provider = getMonetaryConversionsSpi()
                 .getExchangeRateProvider(ConversionQueryBuilder.of().setProviderNames(providers).build());
         return Optional.ofNullable(provider)
                 .orElseThrow(() -> new MonetaryException("No such rate provider: " + Arrays.toString(providers)));
@@ -218,7 +219,7 @@ public final class MonetaryConversions{
      * @throws IllegalArgumentException if no such {@link ExchangeRateProvider} is available.
      */
     public static ExchangeRateProvider getExchangeRateProvider(ConversionQuery conversionQuery){
-        return Optional.ofNullable(MONETARY_CONVERSION_SPI).orElseThrow(() -> new MonetaryException(
+        return Optional.ofNullable(getMonetaryConversionsSpi()).orElseThrow(() -> new MonetaryException(
                 "No MonetaryConversionsSingletonSpi loaded, query functionality is not available."))
                 .getExchangeRateProvider(conversionQuery);
     }
@@ -230,7 +231,7 @@ public final class MonetaryConversions{
      * @return true, if a rate provider is accessible from {@link #getExchangeRateProvider(ConversionQuery)}}.
      */
     public static boolean isExchangeRateProviderAvailable(ConversionQuery conversionQuery){
-        return Optional.ofNullable(MONETARY_CONVERSION_SPI)
+        return Optional.ofNullable(getMonetaryConversionsSpi())
                 .orElseThrow(() -> new MonetaryException("No MonetaryConversionsSingletonSpi " +
                                                                  "loaded, " +
                                                                  "query functionality is not " +
@@ -247,14 +248,14 @@ public final class MonetaryConversions{
      * @return all supported provider ids, never {@code null}.
      */
     public static Collection<String> getConversionProviderNames(){
-        Collection<String> providers = Optional.ofNullable(MONETARY_CONVERSION_SPI).orElseThrow(
+        Collection<String> providers = Optional.ofNullable(getMonetaryConversionsSpi()).orElseThrow(
                 () -> new MonetaryException(
                         "No MonetaryConversionsSingletonSpi loaded, query functionality is not available."))
                 .getProviderNames();
         if(Objects.isNull(providers)){
             Logger.getLogger(MonetaryConversions.class.getName()).warning(
                     "No supported rate/conversion providers returned by SPI: " +
-                            MONETARY_CONVERSION_SPI.getClass().getName());
+                            getMonetaryConversionsSpi().getClass().getName());
             return Collections.emptySet();
         }
         return providers;
@@ -266,12 +267,12 @@ public final class MonetaryConversions{
      * @return the default provider, never {@code null}.
      */
     public static List<String> getDefaultConversionProviderChain(){
-        List<String> defaultChain = Optional.ofNullable(MONETARY_CONVERSION_SPI).orElseThrow(
+        List<String> defaultChain = Optional.ofNullable(getMonetaryConversionsSpi()).orElseThrow(
                 () -> new MonetaryException(
                         "No MonetaryConversionsSingletonSpi loaded, query functionality is not available."))
                 .getDefaultProviderChain();
         Objects.requireNonNull(defaultChain, "No default provider chain provided by SPI: " +
-                MONETARY_CONVERSION_SPI.getClass().getName());
+                getMonetaryConversionsSpi().getClass().getName());
         return defaultChain;
     }
 

--- a/src/main/java/javax/money/format/MonetaryFormats.java
+++ b/src/main/java/javax/money/format/MonetaryFormats.java
@@ -27,7 +27,9 @@ import java.util.logging.Logger;
  */
 public final class MonetaryFormats {
 
-    private static final MonetaryFormatsSingletonSpi MONETARY_FORMATS_SINGLETON_SPI = loadMonetaryFormatsSingletonSpi();
+    private static final MonetaryFormatsSingletonSpi getMonetaryFormatsSpi() {
+        return loadMonetaryFormatsSingletonSpi();
+    }
 
     /**
      * Private singleton constructor.
@@ -61,7 +63,7 @@ public final class MonetaryFormats {
      * @return true, if a corresponding {@link MonetaryAmountFormat} is accessible.
      */
     public static boolean isAvailable(Locale locale, String... providers) {
-        return Optional.ofNullable(MONETARY_FORMATS_SINGLETON_SPI).orElseThrow(() -> new MonetaryException(
+        return Optional.ofNullable(getMonetaryFormatsSpi()).orElseThrow(() -> new MonetaryException(
                 "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available."))
                 .isAvailable(locale, providers);
     }
@@ -89,7 +91,7 @@ public final class MonetaryFormats {
      * @return true, if a corresponding {@link MonetaryAmountFormat} is accessible.
      */
     public static boolean isAvailable(AmountFormatQuery formatQuery) {
-        return Optional.ofNullable(MONETARY_FORMATS_SINGLETON_SPI).orElseThrow(() -> new MonetaryException(
+        return Optional.ofNullable(getMonetaryFormatsSpi()).orElseThrow(() -> new MonetaryException(
                 "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available."))
                 .isAvailable(formatQuery);
     }
@@ -105,7 +107,7 @@ public final class MonetaryFormats {
      *                           corresponding {@link MonetaryAmountFormat} instance.
      */
     public static MonetaryAmountFormat getAmountFormat(AmountFormatQuery formatQuery) {
-        return Optional.ofNullable(MONETARY_FORMATS_SINGLETON_SPI).orElseThrow(() -> new MonetaryException(
+        return Optional.ofNullable(getMonetaryFormatsSpi()).orElseThrow(() -> new MonetaryException(
                 "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available."))
                 .getAmountFormat(formatQuery);
     }
@@ -121,7 +123,7 @@ public final class MonetaryFormats {
      *                           corresponding {@link MonetaryAmountFormat} instance.
      */
     public static Collection<MonetaryAmountFormat> getAmountFormats(AmountFormatQuery formatQuery) {
-        return Optional.ofNullable(MONETARY_FORMATS_SINGLETON_SPI).orElseThrow(() -> new MonetaryException(
+        return Optional.ofNullable(getMonetaryFormatsSpi()).orElseThrow(() -> new MonetaryException(
                 "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available."))
                 .getAmountFormats(formatQuery);
     }
@@ -148,7 +150,7 @@ public final class MonetaryFormats {
      * @return all available locales, never {@code null}.
      */
     public static Set<Locale> getAvailableLocales(String... providers) {
-        return MONETARY_FORMATS_SINGLETON_SPI.getAvailableLocales(providers);
+        return getMonetaryFormatsSpi().getAvailableLocales(providers);
     }
 
     /**
@@ -157,14 +159,14 @@ public final class MonetaryFormats {
      * @return the provider names, never null.
      */
     public static Collection<String> getFormatProviderNames() {
-        Collection<String> providers = Optional.ofNullable(MONETARY_FORMATS_SINGLETON_SPI).orElseThrow(
+        Collection<String> providers = Optional.ofNullable(getMonetaryFormatsSpi()).orElseThrow(
                 () -> new MonetaryException(
                         "No MonetaryFormatsSingletonSpi loaded, query functionality is not available."))
                 .getProviderNames();
         if (Objects.isNull(providers)) {
             Logger.getLogger(MonetaryFormats.class.getName()).warning(
                     "No supported rate/conversion providers returned by SPI: " +
-                            MONETARY_FORMATS_SINGLETON_SPI.getClass().getName());
+                            getMonetaryFormatsSpi().getClass().getName());
             return Collections.emptySet();
         }
         return providers;
@@ -176,7 +178,7 @@ public final class MonetaryFormats {
      * @return the default provider chain, never null.
      */
     public static List<String> getDefaultFormatProviderChain() {
-        return Optional.ofNullable(MONETARY_FORMATS_SINGLETON_SPI).orElseThrow(() -> new MonetaryException(
+        return Optional.ofNullable(getMonetaryFormatsSpi()).orElseThrow(() -> new MonetaryException(
                 "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available."))
                 .getDefaultProviderChain();
     }

--- a/src/test/java/javax/money/AbstractDynamicServiceProviderTest.java
+++ b/src/test/java/javax/money/AbstractDynamicServiceProviderTest.java
@@ -1,0 +1,110 @@
+/*
+ * CREDIT SUISSE IS WILLING TO LICENSE THIS SPECIFICATION TO YOU ONLY UPON THE CONDITION THAT YOU
+ * ACCEPT ALL OF THE TERMS CONTAINED IN THIS AGREEMENT. PLEASE READ THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT CAREFULLY. BY DOWNLOADING THIS SPECIFICATION, YOU ACCEPT THE TERMS AND CONDITIONS OF
+ * THE AGREEMENT. IF YOU ARE NOT WILLING TO BE BOUND BY IT, SELECT THE "DECLINE" BUTTON AT THE
+ * BOTTOM OF THIS PAGE. Specification: JSR-354 Money and Currency API ("Specification") Copyright
+ * (c) 2012-2013, Credit Suisse All rights reserved.
+ */
+package javax.money;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.money.spi.Bootstrap;
+import javax.money.spi.CurrencyProviderSpi;
+import javax.money.spi.ServiceProvider;
+
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * Abstract test supporting to switch SPI implementations by using a ServiceProvider providing manually registered SPIs only. 
+ * @author Matthias Hanisch
+ */
+public abstract class AbstractDynamicServiceProviderTest {
+
+    private ServiceProvider originalServiceProvider;
+    private TestServiceProvider testServiceProvider;
+    
+    /**
+     * Initialized Bootstrap so that default ServiceProvider is enabled. Then stores the default ServiceProvider in
+     * {@link #originalServiceProvider}. Initializes Bootstrap with default ServiceProvider again so that it is
+     * usable in the Test. Also initialized {@link #testServiceProvider}.
+     */
+    @BeforeMethod
+    public void prepare() {
+        Bootstrap.getService(CurrencyProviderSpi.class);
+        ServiceProvider empty = Mockito.mock(ServiceProvider.class);
+        originalServiceProvider= Bootstrap.init(empty);
+        Bootstrap.init(originalServiceProvider);
+        testServiceProvider = new TestServiceProvider();
+    }
+    
+    /**
+     * Restores the default ServiceProvider.
+     */
+    @AfterMethod
+    public void restore() {
+        testServiceProvider.clearServices();
+        Bootstrap.init(originalServiceProvider);
+    }
+    
+    protected final void initTestServiceProvider() {
+        Bootstrap.init(testServiceProvider);
+    }
+    
+    protected final void initOriginalServiceProvider() {
+        Bootstrap.init(originalServiceProvider);
+    }
+
+    /**
+     * Registers a SPI service so that it is accessible via {@link Bootstrap#getService(Class)} when using {@link #testServiceProvider}.
+     * @param serviceType The SPI type.
+     * @param service The SPI instance.
+     */
+    protected final <T> void registerService(Class<T> serviceType, T service) {
+        testServiceProvider.registerService(serviceType, service);
+    }
+    
+    class TestServiceProvider implements ServiceProvider {
+        
+        private Map<Class<?>, List<?>> services = new HashMap<>();
+
+        @Override
+        public int getPriority() {
+            return 0;
+        }
+
+        @Override
+        public <T> List<T> getServices(Class<T> serviceType) {
+            return (List<T>) services.get(serviceType);
+        }
+
+        @Override
+        public <T> T getService(Class<T> serviceType) {
+            List<T> servicesOfType = getServices(serviceType);
+            if(servicesOfType==null||servicesOfType.isEmpty()) {
+                return null;
+            } else {
+                return servicesOfType.get(0);
+            }
+        }
+        
+        public <T> void registerService(Class<T> serviceType, T service) {
+            List<T> servicesOfType = (List<T>) services.get(serviceType);
+            if(servicesOfType==null) {
+                servicesOfType = new ArrayList<>();
+                services.put(serviceType, servicesOfType);
+            }
+            servicesOfType.add(service);
+        }
+        
+        public void clearServices() {
+            services.clear();
+        }
+    }
+}

--- a/src/test/java/javax/money/MonetaryDynamicServiceProviderTest.java
+++ b/src/test/java/javax/money/MonetaryDynamicServiceProviderTest.java
@@ -1,0 +1,199 @@
+/*
+ * CREDIT SUISSE IS WILLING TO LICENSE THIS SPECIFICATION TO YOU ONLY UPON THE CONDITION THAT YOU
+ * ACCEPT ALL OF THE TERMS CONTAINED IN THIS AGREEMENT. PLEASE READ THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT CAREFULLY. BY DOWNLOADING THIS SPECIFICATION, YOU ACCEPT THE TERMS AND CONDITIONS OF
+ * THE AGREEMENT. IF YOU ARE NOT WILLING TO BE BOUND BY IT, SELECT THE "DECLINE" BUTTON AT THE
+ * BOTTOM OF THIS PAGE. Specification: JSR-354 Money and Currency API ("Specification") Copyright
+ * (c) 2012-2013, Credit Suisse All rights reserved.
+ */
+package javax.money;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import javax.money.internal.DefaultMonetaryAmountsSingletonQuerySpi;
+import javax.money.internal.DefaultMonetaryAmountsSingletonSpi;
+import javax.money.spi.Bootstrap;
+import javax.money.spi.MonetaryAmountsSingletonQuerySpi;
+import javax.money.spi.MonetaryAmountsSingletonSpi;
+import javax.money.spi.MonetaryCurrenciesSingletonSpi;
+import javax.money.spi.MonetaryRoundingsSingletonSpi;
+import javax.money.spi.RoundingProviderSpi;
+import javax.money.spi.ServiceProvider;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+
+/**
+ * Test to ensure that singleton SPIs used by {@link Monetary} handle substitution of {@link ServiceProvider} to use when
+ * calling {@link Bootstrap#init(javax.money.spi.ServiceProvider)}. (e.g. in an OSGI environment)
+ * @author Matthias Hanisch
+ *
+ */
+public class MonetaryDynamicServiceProviderTest extends AbstractDynamicServiceProviderTest {
+    
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryCurrenciesSingletonSpi} supports currencies test1 and test2.
+     * Dynamic SPI: Mock supporting currencies test1 and test3. 
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>currency test1 available</li>
+     * <li>currency test2 available</li>
+     * <li>currency test3 <b>not</b> available</li>
+     * <li>use dynamic SPI</li>
+     * <li>currency test1 available</li>
+     * <li>currency test2 <b>not</b> available</li>
+     * <li>currency test3 available</li>
+     * <li>use default SPI</li>
+     * <li>currency test1 available</li>
+     * <li>currency test2 available</li>
+     * <li>currency test3 <b>not</b> available</li>
+     * </ul>
+     * 
+     */
+    @Test
+    public void testMonetaryCurrenciesSingletonSpi() {
+        // DefaultMonetaryCurrenciesSingletonSpi is used
+        assertCurrencyAvailable("test1");
+        assertCurrencyAvailable("test2");
+        assertCurrencyMissing("test3");
+        MonetaryCurrenciesSingletonSpi mockSingleton = Mockito.mock(MonetaryCurrenciesSingletonSpi.class);
+        registerService(MonetaryCurrenciesSingletonSpi.class, mockSingleton);
+        doAnswer(new Answer<CurrencyUnit>() {
+            private List<String> supportedCurrencies = Arrays.asList("test1","test3");
+            @Override
+            public CurrencyUnit answer(InvocationOnMock invocation)
+                    throws Throwable {
+                String currencyCode =(String)invocation.getArguments()[0];
+                if(supportedCurrencies.contains(currencyCode)) {
+                    return new TestCurrency(currencyCode, 1,2);
+                }
+                throw new UnknownCurrencyException(currencyCode);
+            }
+        }).when(mockSingleton).getCurrency(anyString());
+        initTestServiceProvider();
+        // DynamicMonetaryCurrenciesSingletonSpi is used
+        assertCurrencyAvailable("test1");
+        assertCurrencyMissing("test2");
+        assertCurrencyAvailable("test3");
+        initOriginalServiceProvider();
+        // DefaultMonetaryCurrenciesSingletonSpi is used again
+        assertCurrencyAvailable("test1");
+        assertCurrencyAvailable("test2");
+        assertCurrencyMissing("test3");
+    }
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryAmountsSingletonSpi} supports a {@link MonetaryAmountFactory} creating instances of DummyAmount.
+     * Dynamic SPI: Mock supporting a {@link MonetaryAmountFactory} creating a mocked {@link MonetaryAmount}
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>created MonetaryAmount should be a DummyAmount</li>
+     * <li>use dynamic SPI</li>
+     * <li>created MonetaryAmount should match the mocked Amount</li>
+     * <li>use default SPI</li>
+     * <li>created MonetaryAmount should be a DummyAmount</li>
+     * </ul>     
+     */
+    @Test
+    public void testMonetaryAmountsSingletonSpi() {
+        assertTrue(Monetary.getDefaultAmountFactory().create()instanceof DummyAmount);
+        MonetaryAmountsSingletonSpi mockSingleton = mock(MonetaryAmountsSingletonSpi.class);
+        MonetaryAmountFactory<?> mockFactory = mock(MonetaryAmountFactory.class);
+        MonetaryAmount mockAmount = mock(MonetaryAmount.class);
+        doReturn(mockFactory).when(mockSingleton).getDefaultAmountFactory();
+        doReturn(mockAmount).when(mockFactory).create();
+        registerService(MonetaryAmountsSingletonSpi.class, mockSingleton);
+        initTestServiceProvider();
+        assertFalse(Monetary.getDefaultAmountFactory().create()instanceof DummyAmount);
+        assertEquals(Monetary.getDefaultAmountFactory().create(), mockAmount);
+        initOriginalServiceProvider();
+        assertTrue(Monetary.getDefaultAmountFactory().create()instanceof DummyAmount);
+    }
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryAmountsSingletonQuerySpi} supports {@link MonetaryAmountFactoryQuery} for DummyAmount.
+     * Dynamic SPI: Mock not supporting {@link MonetaryAmountFactoryQuery} for none MonetaryMount at all.
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>query for DummyAmount should be true</li>
+     * <li>use dynamic SPI</li>
+     * <li>query for DummyAmount should be false</li>
+     * <li>use default SPI</li>
+     * <li>query for DummyAmount should be true</li>
+     * </ul>
+     */
+    @Test
+    public void testMonetaryAmountsSingletonQuerySpi() {
+        MonetaryAmountFactoryQuery query = MonetaryAmountFactoryQueryBuilder.of()
+        .setTargetType(DummyAmount.class).build();
+        assertTrue(Monetary.isAvailable(query));
+        MonetaryAmountsSingletonQuerySpi mock= mock(MonetaryAmountsSingletonQuerySpi.class);
+        doReturn(Boolean.FALSE).when(mock).isAvailable(any(MonetaryAmountFactoryQuery.class));
+        registerService(MonetaryAmountsSingletonQuerySpi.class, mock);
+        initTestServiceProvider();
+        assertFalse(Monetary.isAvailable(query));
+        initOriginalServiceProvider();
+        assertTrue(Monetary.isAvailable(query));
+    }
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryRoundingsSingletonSpi} uses {@link RoundingProviderSpi} supporting two rounding names.
+     * Dynamic SPI: Mock supporting one rounding name.
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>number of rounding names should be two</li>
+     * <li>use dynamic SPI</li>
+     * <li>number of rounding names should be one</li>
+     * <li>use default SPI</li>
+     * <li>number of rounding names should be two</li>
+     * </ul>
+     */
+    @Test
+    public void testMonetaryRoundingsSingletonSpi() {
+        assertEquals(Monetary.getRoundingNames().size(),2);
+        MonetaryRoundingsSingletonSpi mock = mock(MonetaryRoundingsSingletonSpi.class);
+        doReturn(new HashSet<>(Arrays.asList("dummyRounding"))).when(mock).getRoundingNames();
+        registerService(MonetaryRoundingsSingletonSpi.class, mock);
+        initTestServiceProvider();
+        assertEquals(Monetary.getRoundingNames().size(),1);
+        initOriginalServiceProvider();
+        assertEquals(Monetary.getRoundingNames().size(),2);
+    }
+    
+    private void assertCurrencyAvailable(String currency) {
+        CurrencyUnit cur = Monetary.getCurrency(currency);
+        assertNotNull(cur);
+    }
+    
+    private void assertCurrencyMissing(String currency) {
+        try {
+            CurrencyUnit cur = Monetary.getCurrency(currency);
+            fail(String.format("currency %s should not be available, but got %s", currency, cur));
+        } catch(UnknownCurrencyException ex) {
+            ex.printStackTrace();
+            // expected
+        }
+    }
+    
+
+}

--- a/src/test/java/javax/money/TestCurrency.java
+++ b/src/test/java/javax/money/TestCurrency.java
@@ -55,7 +55,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable, Comparabl
     /**
      * Private constructor.
      */
-    private TestCurrency(String code, int numCode, int fractionDigits) {
+    TestCurrency(String code, int numCode, int fractionDigits) {
         this.currencyCode = code;
         this.numericCode = numCode;
         this.defaultFractionDigits = fractionDigits;

--- a/src/test/java/javax/money/convert/MonetaryConversionsDynamicServiceProviderTest.java
+++ b/src/test/java/javax/money/convert/MonetaryConversionsDynamicServiceProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * CREDIT SUISSE IS WILLING TO LICENSE THIS SPECIFICATION TO YOU ONLY UPON THE CONDITION THAT YOU
+ * ACCEPT ALL OF THE TERMS CONTAINED IN THIS AGREEMENT. PLEASE READ THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT CAREFULLY. BY DOWNLOADING THIS SPECIFICATION, YOU ACCEPT THE TERMS AND CONDITIONS OF
+ * THE AGREEMENT. IF YOU ARE NOT WILLING TO BE BOUND BY IT, SELECT THE "DECLINE" BUTTON AT THE
+ * BOTTOM OF THIS PAGE. Specification: JSR-354 Money and Currency API ("Specification") Copyright
+ * (c) 2012-2013, Credit Suisse All rights reserved.
+ */
+package javax.money.convert;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import javax.money.internal.DefaultMonetaryAmountsSingletonQuerySpi;
+import javax.money.internal.DefaultMonetaryAmountsSingletonSpi;
+import javax.money.spi.Bootstrap;
+import javax.money.spi.MonetaryAmountsSingletonQuerySpi;
+import javax.money.spi.MonetaryAmountsSingletonSpi;
+import javax.money.spi.MonetaryConversionsSingletonSpi;
+import javax.money.spi.MonetaryCurrenciesSingletonSpi;
+import javax.money.spi.MonetaryRoundingsSingletonSpi;
+import javax.money.spi.RoundingProviderSpi;
+import javax.money.spi.ServiceProvider;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+
+import javax.money.AbstractDynamicServiceProviderTest;
+import javax.money.format.MonetaryFormats;
+import javax.money.format.MonetaryFormats.DefaultMonetaryFormatsSingletonSpi;
+
+/**
+ * Test to ensure that singleton SPIs used by {@link MonetaryConversions} handle substitution of {@link ServiceProvider} to use when
+ * calling {@link Bootstrap#init(javax.money.spi.ServiceProvider)}. (e.g. in an OSGI environment)
+ * @author Matthias Hanisch
+ *
+ */
+public class MonetaryConversionsDynamicServiceProviderTest
+        extends AbstractDynamicServiceProviderTest {
+
+    /**
+     * Default test SPI: {@link TestMonetaryConversionsSingletonSpi} supports one conversion provider name.
+     * Dynamic SPI: Mock supporting two conversion provider names.
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>number of conversion provider names should be one</li>
+     * <li>use dynamic SPI</li>
+     * <li>number of conversion provider names should be two</li>
+     * <li>use default SPI</li>
+     * <li>number of conversion provider names should be one</li>
+     * </ul>
+     */
+    @Test
+    public void testMonetaryConversionsSingletonSpi() {
+        assertEquals(MonetaryConversions.getConversionProviderNames().size(),1);
+        MonetaryConversionsSingletonSpi mock = mock(MonetaryConversionsSingletonSpi.class);
+        doReturn(new HashSet<String>(Arrays.asList("conversionProviderOne","conversionProviderTwo"))).when(mock).getProviderNames();
+        registerService(MonetaryConversionsSingletonSpi.class, mock);
+        initTestServiceProvider();
+        assertEquals(MonetaryConversions.getConversionProviderNames().size(),2);
+        initOriginalServiceProvider();
+        assertEquals(MonetaryConversions.getConversionProviderNames().size(),1);
+        
+    }
+}

--- a/src/test/java/javax/money/format/MonetaryFormatsDynamicServiceProviderTest.java
+++ b/src/test/java/javax/money/format/MonetaryFormatsDynamicServiceProviderTest.java
@@ -1,0 +1,60 @@
+/*
+ * CREDIT SUISSE IS WILLING TO LICENSE THIS SPECIFICATION TO YOU ONLY UPON THE CONDITION THAT YOU
+ * ACCEPT ALL OF THE TERMS CONTAINED IN THIS AGREEMENT. PLEASE READ THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT CAREFULLY. BY DOWNLOADING THIS SPECIFICATION, YOU ACCEPT THE TERMS AND CONDITIONS OF
+ * THE AGREEMENT. IF YOU ARE NOT WILLING TO BE BOUND BY IT, SELECT THE "DECLINE" BUTTON AT THE
+ * BOTTOM OF THIS PAGE. Specification: JSR-354 Money and Currency API ("Specification") Copyright
+ * (c) 2012-2013, Credit Suisse All rights reserved.
+ */
+package javax.money.format;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import javax.money.AbstractDynamicServiceProviderTest;
+import javax.money.format.MonetaryFormats.DefaultMonetaryFormatsSingletonSpi;
+import javax.money.spi.Bootstrap;
+import javax.money.spi.MonetaryFormatsSingletonSpi;
+import javax.money.spi.ServiceProvider;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test to ensure that singleton SPIs used by {@link MonetaryFormats} handle substitution of {@link ServiceProvider} to use when
+ * calling {@link Bootstrap#init(javax.money.spi.ServiceProvider)}. (e.g. in an OSGI environment)
+ * @author Matthias Hanisch
+ *
+ */
+public class MonetaryFormatsDynamicServiceProviderTest
+        extends AbstractDynamicServiceProviderTest {
+
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryFormatsSingletonSpi} supports one format provider name.
+     * Dynamic SPI: Mock supporting two format provider names.
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>number of format provider names should be one</li>
+     * <li>use dynamic SPI</li>
+     * <li>number of format provider names should be two</li>
+     * <li>use default SPI</li>
+     * <li>number of format provider names should be one</li>
+     * </ul>
+     */
+    @Test
+    public void testMonetaryFormatsSingletonSpi() {
+        assertEquals(MonetaryFormats.getFormatProviderNames().size(),1);
+        MonetaryFormatsSingletonSpi mock = mock(MonetaryFormatsSingletonSpi.class);
+        doReturn(new HashSet<String>(Arrays.asList("formatProviderOne","formatProviderTow"))).when(mock).getProviderNames();
+        registerService(MonetaryFormatsSingletonSpi.class, mock);
+        initTestServiceProvider();
+        assertEquals(MonetaryFormats.getFormatProviderNames().size(),2);
+        initOriginalServiceProvider();
+        assertEquals(MonetaryFormats.getFormatProviderNames().size(),1);
+    }
+}


### PR DESCRIPTION
I just came across money-api and wanted to use the libary in OSGI environment (Karaf 4.0.6). As **money-api** is using ServiceLoader to locate registered SPI instances I used aries-spifly to get ServiceLoader working in OSGI.
 Unfortunately **money-api** itself breaks this. The three classes Monetary, MonetearyConversions and MonetaryFormats are using static members to reference SPI instances. In the OSGI environment SPI instance will be registered dynamically. So registered SPI instances are missing if Monetary, MonetaryConversions or MonetaryFormats already resolved SPI instances.

 I suggest to resolve the SPI instances in Monetary, MonetaryConversions and MonetaryFormats on request. In OSGI environment this would support dynamically adding and removing of SPI instances.
