### PR TITLE
Uses monetary currencies singleton spi

### DIFF
--- a/src/main/java/java/money/module-info.java
+++ b/src/main/java/java/money/module-info.java
@@ -19,6 +19,7 @@ module java.money {
     uses javax.money.spi.MonetaryAmountsSingletonQuerySpi;
     uses javax.money.spi.MonetaryAmountsSingletonSpi;
     uses javax.money.spi.MonetaryConversionsSingletonSpi;
+    uses javax.money.spi.MonetaryCurrenciesSingletonSpi;
     uses javax.money.spi.MonetaryFormatsSingletonSpi;
     uses javax.money.spi.MonetaryRoundingsSingletonSpi;
     uses javax.money.spi.RoundingProviderSpi;


### PR DESCRIPTION
Monetary.MONETARY_CURRENCIES_SINGLETON_SPI() tries to use ServiceLoader
for loading MonetaryCurrenciesSingletonSpi but it is not declared in
the module info.
    
This should fix https://github.com/JavaMoney/jsr354-ri/issues/219

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-api/96)
<!-- Reviewable:end -->
