### PR TITLE
Remove non-Services

### DIFF
--- a/src/main/java/java/money/module-info.java
+++ b/src/main/java/java/money/module-info.java
@@ -24,6 +24,4 @@ module java.money {
     uses javax.money.spi.RoundingProviderSpi;
     uses javax.money.spi.ServiceProvider;
     uses javax.money.convert.ExchangeRateProvider;
-    uses javax.money.convert.ExchangeRateProviderSupplier;
-    uses javax.money.format.MonetaryAmountFormat;
 }


### PR DESCRIPTION
To the best of my understanding ExchangeRateProviderSupplier and
MonetaryAmountFormat are not ServiceLoader services. Their
implementations do not fit the definition. As a consequence they should
not be declared as uses.

 [1] https://docs.oracle.com/javase/specs/jls/se10/html/jls-7.html#jls-7.7.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-api/97)
<!-- Reviewable:end -->
