### PR TITLE
Update CurrencyQuery to Make Timestamp Optional

### DIFF
--- a/src/main/java/javax/money/CurrencyQuery.java
+++ b/src/main/java/javax/money/CurrencyQuery.java
@@ -26,8 +26,8 @@ import java.util.Locale;
  * provides information such as
  * <ul>
  * <li>the providers that may provide {@link CurrencyUnit} instances
- * <li>a target timestamp / temporal unit, when the {@link CurrencyUnit} instances should be valid
- * <li>any other attributes, identified by the attribute type, e.g. regions, tenants etc.
+ * <li>any other attributes, identified by the attribute type, e.g. regions, tenants,
+ *     a target timestamp / temporal unit, when the {@link CurrencyUnit} instances should be valid, etc.
  * </ul>
  * The effective attributes supported are only determined by the implementations of {@link javax.money.spi
  * .CurrencyProviderSpi}.


### PR DESCRIPTION
The class comment of CurrencyQuery still mentions the timestamp
although that was removed a long time ago. Update the class Javadoc
to reflect this and move it into the provider specific section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-api/117)
<!-- Reviewable:end -->
