### PR TITLE
Fix return Javadoc of CurrencyQuery

### DIFF
--- a/src/main/java/javax/money/CurrencyQuery.java
+++ b/src/main/java/javax/money/CurrencyQuery.java
@@ -81,7 +81,7 @@ public final class CurrencyQuery extends AbstractQuery implements Serializable {
     /**
      * Gets the currency codes, or the regular expression to select codes.
      *
-     * @return the query for chaining.
+     * @return the target currency codes or the regular expression, never null.
      */
     public Collection<String> getCurrencyCodes() {
         Collection<String> result = get(KEY_QUERY_CURRENCY_CODES, Collection.class);
@@ -94,7 +94,7 @@ public final class CurrencyQuery extends AbstractQuery implements Serializable {
     /**
      * Gets the numeric codes. Setting it to -1 search for currencies that have no numeric code.
      *
-     * @return the query for chaining.
+     * @return the target numeric codes, never null.
      */
     public Collection<Integer> getNumericCodes() {
         Collection<Integer> result = get(KEY_QUERY_NUMERIC_CODES, Collection.class);


### PR DESCRIPTION
The return Javadoc of the CurrencyQuery methods getCurrencyCodes and
getNumericCodes is wrong. It was likely copy and pasted from
CurrencyQueryBuilder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-api/118)
<!-- Reviewable:end -->
