### PR TITLE
Fix typo in MonetaryCurrenciesSingletonSpi Javadoc

### DIFF
--- a/src/main/java/javax/money/spi/MonetaryCurrenciesSingletonSpi.java
+++ b/src/main/java/javax/money/spi/MonetaryCurrenciesSingletonSpi.java
@@ -42,7 +42,7 @@ public interface MonetaryCurrenciesSingletonSpi {
     List<String> getDefaultProviderChain();
 
     /**
-     * Access a list of the currently registered providers. Th names can be used to
+     * Access a list of the currently registered providers. The names can be used to
      * access subsets of the overall currency range by calling {@link #getCurrencies(String...)}.
      *
      * @return the currencies returned by the given provider chain. If not provider names are provided


### PR DESCRIPTION
Fix typo in the Javadoc of
MonetaryCurrenciesSingletonSpi#getProviderNames().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-api/121)
<!-- Reviewable:end -->
