### PR TITLE
Switch build to OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: java
 jdk:
-  - oraclejdk9
-addons:
-  apt:
-    packages:
-      - oracle-java9-installer
+  - openjdk11
 
 after_success:
   - mvn deploy -Dmaven.test.skip -DcreateDocs=true -s settings.xml


### PR DESCRIPTION
Java 9 is EoL which causes some builds to fail like #121.
Java 11 is the current LTS however Oracle no longer provides updates
for their OpenJDK 11 builds and Oracle JDK 11 has an OTN license.
This makes openjdk11 currently the best option for TravisCI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-api/122)
<!-- Reviewable:end -->
