### PR TITLE
Clean up Monetary implementation

### DIFF
--- a/src/main/java/javax/money/Monetary.java
+++ b/src/main/java/javax/money/Monetary.java
@@ -21,7 +21,6 @@ import javax.money.spi.*;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
@@ -40,8 +39,11 @@ import java.util.logging.Logger;
 public final class Monetary {
     /**
      * The used {@link javax.money.spi.MonetaryCurrenciesSingletonSpi} instance.
+     * 
+     * @return the used {@link javax.money.spi.MonetaryCurrenciesSingletonSpi} instance,
+     *         never {@code null}
      */
-    private static MonetaryCurrenciesSingletonSpi MONETARY_CURRENCIES_SINGLETON_SPI() {
+    private static MonetaryCurrenciesSingletonSpi monetaryCurrenciesSingletonSpi() {
         try {
             return Optional.ofNullable(Bootstrap
                     .getService(MonetaryCurrenciesSingletonSpi.class)).orElseGet(
@@ -83,6 +85,9 @@ public final class Monetary {
 
     /**
      * The used {@link javax.money.spi.MonetaryCurrenciesSingletonSpi} instance.
+     * 
+     * @return the used {@link javax.money.spi.MonetaryCurrenciesSingletonSpi} instance,
+     *         never {@code null}
      */
     private static MonetaryRoundingsSingletonSpi monetaryRoundingsSingletonSpi() {
         try {
@@ -108,8 +113,7 @@ public final class Monetary {
      * @return the set of provider names, never {@code null}.
      */
     public static Set<String> getRoundingProviderNames() {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .getProviderNames();
     }
 
@@ -119,8 +123,7 @@ public final class Monetary {
      * @return the chained list of provider names, never {@code null}.
      */
     public static List<String> getDefaultRoundingProviderChain() {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .getDefaultProviderChain();
     }
 
@@ -133,8 +136,7 @@ public final class Monetary {
      * @return the (shared) default rounding instance.
      */
     public static MonetaryRounding getDefaultRounding() {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .getDefaultRounding();
     }
 
@@ -151,8 +153,7 @@ public final class Monetary {
      * rounding, never {@code null}.
      */
     public static MonetaryRounding getRounding(CurrencyUnit currencyUnit, String... providers) {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .getRounding(currencyUnit, providers);
     }
 
@@ -169,8 +170,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static MonetaryRounding getRounding(String roundingName, String... providers) {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .getRounding(roundingName, providers);
     }
 
@@ -184,8 +184,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static MonetaryRounding getRounding(RoundingQuery roundingQuery) {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .getRounding(roundingQuery);
     }
 
@@ -200,8 +199,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static boolean isRoundingAvailable(String roundingName, String... providers) {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .isRoundingAvailable(roundingName, providers);
     }
 
@@ -217,8 +215,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static boolean isRoundingAvailable(CurrencyUnit currencyUnit, String... providers) {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .isRoundingAvailable(currencyUnit, providers);
     }
 
@@ -232,8 +229,7 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static boolean isRoundingAvailable(RoundingQuery roundingQuery) {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .isRoundingAvailable(roundingQuery);
     }
 
@@ -246,8 +242,7 @@ public final class Monetary {
      * @return all {@link javax.money.MonetaryRounding} instances matching the query, never {@code null}.
      */
     public static Collection<MonetaryRounding> getRoundings(RoundingQuery roundingQuery) {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .getRoundings(roundingQuery);
     }
 
@@ -260,8 +255,7 @@ public final class Monetary {
      * @return the set of custom rounding ids, never {@code null}.
      */
     public static Set<String> getRoundingNames(String... providers) {
-        return Optional.ofNullable(monetaryRoundingsSingletonSpi()).orElseThrow(
-                () -> new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available."))
+        return monetaryRoundingsSingletonSpi()
                 .getRoundingNames(providers);
     }
 
@@ -384,8 +378,7 @@ public final class Monetary {
      * @throws UnknownCurrencyException if no such currency exists.
      */
     public static CurrencyUnit getCurrency(String currencyCode, String... providers) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
-                () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
+        return monetaryCurrenciesSingletonSpi()
                 .getCurrency(currencyCode, providers);
     }
 
@@ -401,8 +394,7 @@ public final class Monetary {
      * @throws UnknownCurrencyException if no such currency exists.
      */
     public static CurrencyUnit getCurrency(Locale locale, String... providers) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
-                () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
+        return monetaryCurrenciesSingletonSpi()
                 .getCurrency(locale, providers);
     }
 
@@ -418,7 +410,7 @@ public final class Monetary {
      * @throws UnknownCurrencyException if no such currency exists.
      */
     public static Set<CurrencyUnit> getCurrencies(Locale locale, String... providers) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
+        return Optional.ofNullable(monetaryCurrenciesSingletonSpi()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getCurrencies(locale, providers);
     }
@@ -433,7 +425,7 @@ public final class Monetary {
      * would return a result for the given code.
      */
     public static boolean isCurrencyAvailable(String code, String... providers) {
-        return Objects.nonNull(MONETARY_CURRENCIES_SINGLETON_SPI()) && MONETARY_CURRENCIES_SINGLETON_SPI().isCurrencyAvailable(code, providers);
+        return monetaryCurrenciesSingletonSpi().isCurrencyAvailable(code, providers);
     }
 
     /**
@@ -446,7 +438,7 @@ public final class Monetary {
      * result containing a currency with the given code.
      */
     public static boolean isCurrencyAvailable(Locale locale, String... providers) {
-        return Objects.nonNull(MONETARY_CURRENCIES_SINGLETON_SPI()) && MONETARY_CURRENCIES_SINGLETON_SPI().isCurrencyAvailable(locale, providers);
+        return monetaryCurrenciesSingletonSpi().isCurrencyAvailable(locale, providers);
     }
 
     /**
@@ -456,8 +448,7 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static Collection<CurrencyUnit> getCurrencies(String... providers) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
-                () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
+        return monetaryCurrenciesSingletonSpi()
                 .getCurrencies(providers);
     }
 
@@ -468,8 +459,7 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static CurrencyUnit getCurrency(CurrencyQuery query) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
-                () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
+        return monetaryCurrenciesSingletonSpi()
                 .getCurrency(query);
     }
 
@@ -481,7 +471,7 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static Collection<CurrencyUnit> getCurrencies(CurrencyQuery query) {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
+        return Optional.ofNullable(monetaryCurrenciesSingletonSpi()).orElseThrow(
                 () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
                 .getCurrencies(query);
     }
@@ -492,8 +482,7 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static Set<String> getCurrencyProviderNames() {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
-                () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
+        return monetaryCurrenciesSingletonSpi()
                 .getProviderNames();
     }
 
@@ -504,8 +493,7 @@ public final class Monetary {
      * @return the ordered list provider names, modelling the default provider chain used, never null.
      */
     public static List<String> getDefaultCurrencyProviderChain() {
-        return Optional.ofNullable(MONETARY_CURRENCIES_SINGLETON_SPI()).orElseThrow(
-                () -> new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup."))
+        return monetaryCurrenciesSingletonSpi()
                 .getDefaultProviderChain();
     }
 


### PR DESCRIPTION
Clean up the implementation of the Monetary class

 * use the same naming convention for all static methods
 * remove redundant null checks

Fixes #90

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-api/125)
<!-- Reviewable:end -->
