### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<hamcrest.version>2.2</hamcrest.version>
 		<jacoco.version>0.8.7</jacoco.version>
 		<javadoc.version>3.0.1</javadoc.version>
+		<closeTestReports>true</closeTestReports>
 	</properties>
 
 	<organization>
@@ -518,6 +519,7 @@
 						<excludes>
 							<exclude>**/Abstract*.java</exclude>
 						</excludes>
+						<disableXmlReport>${closeTestReports}</disableXmlReport>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-api/136)
<!-- Reviewable:end -->
